### PR TITLE
add links to the substance math editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ $ make run
 Converts from AsciiMath, LaTeX,MathML to LaTeX, MathML  
 https://github.com/oerpub/mathconverter
 
-# Math Editor plugin for substance
+## Math Editor plugin for substance
 
-I forked the `substance-examples` repo to get started quickly but it should probably live in a separate repo (`substance-math-editor`) and then cc the substance team about it.
+@philschatz forked the `substance-examples` repo to get started quickly but it should probably live in a separate repo (`substance-math-editor`) and then cc the substance team about it.
 
 https://github.com/philschatz/substance-editor and maybe-out-of-date demo: http://philschatz.com/substance-editor/dist/math-editor/  (see repo link for more up-to-date version)
+
+
+![substance-math-editor](https://cloud.githubusercontent.com/assets/253202/20938581/9eecd334-bbb9-11e6-953a-5a510a325f4a.gif)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ $ make run
 
 Converts from AsciiMath, LaTeX,MathML to LaTeX, MathML  
 https://github.com/oerpub/mathconverter
+
+# Math Editor plugin for substance
+
+I forked the `substance-examples` repo to get started quickly but it should probably live in a separate repo (`substance-math-editor`) and then cc the substance team about it.
+
+https://github.com/philschatz/substance-editor and maybe-out-of-date demo: http://philschatz.com/substance-editor/dist/math-editor/  (see repo link for more up-to-date version)


### PR DESCRIPTION
# Features

![substance-math-editor](https://cloud.githubusercontent.com/assets/253202/20938581/9eecd334-bbb9-11e6-953a-5a510a325f4a.gif)

